### PR TITLE
アプリ側から作物の収穫をできるようにする

### DIFF
--- a/CookieWatcher/Models/GardenTile.cs
+++ b/CookieWatcher/Models/GardenTile.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Mvvm;
+﻿using Prism.Commands;
+using Prism.Mvvm;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -21,7 +22,7 @@ namespace CookieWatcher.Models
         /// </summary>
         public string CropIDName {
             #region
-            get => cropIDName;
+            get => cropIDName.Replace("Icon", "");
             set => SetProperty(ref cropIDName, value);
         }
 

--- a/CookieWatcher/ViewModels/MainWindowViewModel.cs
+++ b/CookieWatcher/ViewModels/MainWindowViewModel.cs
@@ -4,6 +4,7 @@ using OpenQA.Selenium.Chrome;
 using Prism.Commands;
 using Prism.Mvvm;
 using System;
+using System.Collections.Generic;
 using System.Timers;
 using System.Windows.Controls;
 

--- a/CookieWatcher/ViewModels/MainWindowViewModel.cs
+++ b/CookieWatcher/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using Prism.Commands;
 using Prism.Mvvm;
 using System;
 using System.Timers;
+using System.Windows.Controls;
 
 namespace CookieWatcher.ViewModels
 {
@@ -101,6 +102,20 @@ namespace CookieWatcher.ViewModels
         }
 
         private DelegateCommand closeDriverCommand;
+        #endregion
+
+
+        public DelegateCommand<ListViewItem> HarvestCommand {
+            #region
+            get => harvestCommand ?? (harvestCommand = new DelegateCommand<ListViewItem>((ListViewItem param) => {
+                var gardenTile = param.Content as GardenTile;
+                if (gardenTile != null && driver.FindElement(By.Id(gardenTile.CropIDName)).Displayed) {
+                    driver.FindElement(By.Id(gardenTile.CropIDName)).Click();
+                }
+            }));
+        }
+
+        private DelegateCommand<ListViewItem> harvestCommand;
         #endregion
     }
 }

--- a/CookieWatcher/Views/MainWindow.xaml
+++ b/CookieWatcher/Views/MainWindow.xaml
@@ -119,6 +119,25 @@
         <TabControl Grid.Row="1">
             <TabItem Header="Garden">
                 <ListView ItemsSource="{Binding Watcher.Crops}">
+
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <ContentControl>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding Level}"/>
+                                    <TextBlock Text="{Binding CropName}"/>
+                                </StackPanel>
+                                <i:Interaction.Triggers>
+                                    <i:EventTrigger EventName="MouseDoubleClick">
+                                        <i:InvokeCommandAction Command="{Binding RowClickCommand}"
+                                                               CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor,AncestorType=ListView}}" 
+                                                               />
+                                    </i:EventTrigger>
+                                </i:Interaction.Triggers>
+                            </ContentControl>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+
                     <ListView.ItemContainerStyle>
                         <Style TargetType="{x:Type ListViewItem}">
                             <Style.Triggers>
@@ -129,19 +148,7 @@
                         </Style>
 
                     </ListView.ItemContainerStyle>
-                    <ListView.View>
-                        <GridView>
-                            <GridViewColumn Header="level"
-                                            DisplayMemberBinding="{Binding Level}"
-                                            />
 
-                            <GridViewColumn Header="name"
-                                            DisplayMemberBinding="{Binding CropName}"
-                                            Width="200"
-                                            />
-
-                        </GridView>
-                    </ListView.View>
                 </ListView>
             </TabItem>
 

--- a/CookieWatcher/Views/MainWindow.xaml
+++ b/CookieWatcher/Views/MainWindow.xaml
@@ -123,10 +123,22 @@
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <ContentControl>
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding Level}"/>
-                                    <TextBlock Text="{Binding CropName}"/>
-                                </StackPanel>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="1*"/>
+                                        <ColumnDefinition Width="8*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="{Binding Level}"
+                                               Grid.Column="0"
+                                               Margin="2,0,2,0"
+                                               />
+                                    <TextBlock Text="{Binding CropName}"
+                                               Grid.Column="1"
+                                               Width="300"
+                                               HorizontalAlignment="Stretch"
+                                               />
+                                </Grid>
+
                                 <i:Interaction.Triggers>
                                     <i:EventTrigger EventName="MouseDoubleClick">
                                         <i:InvokeCommandAction Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Window},Path=DataContext.HarvestCommand}"

--- a/CookieWatcher/Views/MainWindow.xaml
+++ b/CookieWatcher/Views/MainWindow.xaml
@@ -129,8 +129,8 @@
                                 </StackPanel>
                                 <i:Interaction.Triggers>
                                     <i:EventTrigger EventName="MouseDoubleClick">
-                                        <i:InvokeCommandAction Command="{Binding RowClickCommand}"
-                                                               CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor,AncestorType=ListView}}" 
+                                        <i:InvokeCommandAction Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Window},Path=DataContext.HarvestCommand}"
+                                                               CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor,AncestorType=ListViewItem}}" 
                                                                />
                                     </i:EventTrigger>
                                 </i:Interaction.Triggers>


### PR DESCRIPTION
- 仕様変更 / 作物リストのビューの仕様を変更
- 機能追加 / アプリ側のリストクリックで作物の収穫ができるよう実装
- 作物リスト上のクリックが有効な領域を拡大
